### PR TITLE
uninit libaio context

### DIFF
--- a/include/asio/detail/impl/lib_aio_descriptor_service.ipp
+++ b/include/asio/detail/impl/lib_aio_descriptor_service.ipp
@@ -73,6 +73,7 @@ void lib_aio_descriptor_service::destroy(
 
     asio::error_code ignored_ec;
     descriptor_ops::close(impl.descriptor_, impl.state_, ignored_ec);
+    destroy_aio_context();
   }
 }
 

--- a/include/asio/detail/lib_aio_descriptor_service.hpp
+++ b/include/asio/detail/lib_aio_descriptor_service.hpp
@@ -34,6 +34,7 @@
 #include "asio/detail/memory.hpp"
 #include "asio/detail/noncopyable.hpp"
 #include "asio/posix/descriptor_base.hpp"
+#include "asio/detail/reactive_wait_op.hpp"
 #include "asio/detail/reactor.hpp"
 #include "asio/file_base.hpp"
 

--- a/include/asio/detail/lib_aio_io_operation.hpp
+++ b/include/asio/detail/lib_aio_io_operation.hpp
@@ -88,6 +88,11 @@ public:
     }
   }
 
+  ASIO_DECL void destroy_aio_context() {
+    ::close(event_fd_);
+    ::io_destroy(aio_ctx_);
+  }
+
   //submit async write some.
   template<typename ConstBufferSequence>
   ASIO_DECL bool aio_io_submit_write(int descriptor, 


### PR DESCRIPTION
should destroy libaio context when basic_stream_file destruct.